### PR TITLE
CIP-0120: Remove Adjusting Validator Caps for High-Burn Environments section

### DIFF
--- a/cip-0120/cip-0120.md
+++ b/cip-0120/cip-0120.md
@@ -60,10 +60,6 @@ SV Nodes do not need to burn CC to purchase traffic. Their transaction submissio
 
 The minting and reward sharing of traffic-based validator rewards must work [analogous to traffic-based app rewards](https://docs.canton.network/global-synchronizer/splice-fundamentals/reward-sharing): using either CIP-0073 Minting Delegations or the built in automation in a validator node.
 
-### Adjusting Validator Caps for High-Burn Environments
-
-During periods of high network activity where the Burn-Mint Equilibrium (BME) ratio exceeds 1.1, validators hit their 20% validatorRewardCap. To offset the reduction in submitting validator rewards and ensure fair validator compensation during traffic spikes, this CIP proposes increasing the standard validator dynamic minting cap from 20% to 30% of the maximum round allowance. This provides validators with the necessary headroom to access unminted CC supply during high-burn rounds, ensuring their rewards scale appropriately with their actual workload. This adjustment does not alter the baseline 18% target allocation, nor does it reduce the caps of Application Providers or Super Validators.
-
 ## Technical Specification
 
 ### Principles


### PR DESCRIPTION
This PR removes the "Adjusting Validator Caps for High-Burn Environments" section from CIP-0120 (Traffic-Based Validator Rewards and Confirming Validator Incentives).

Author: David Richards